### PR TITLE
Use different baseUri and don't send token in query string

### DIFF
--- a/lib/apiUrl.js
+++ b/lib/apiUrl.js
@@ -18,7 +18,7 @@
 		}
 		if (options.oauth) {
 			queryObj = {};
-			baseUri = 'https://api-proxy.pipedrive.com';
+			baseUri = 'https://api.pipedrive.com';
 		}
 
 		return baseUri + '/' + path + (_.keys(queryObj).length > 0 ? '?' + qs.stringify(queryObj) : '');

--- a/lib/restHandlers.js
+++ b/lib/restHandlers.js
@@ -70,7 +70,7 @@
 	// GET /items
 	RestHandlers.prototype.listItems = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = object == 'authorizations' ? { multipart: false, data: paramsToSupply, oauthToken: this.options.oauth && this.options.apiToken } : { query: qs.stringify(paramsToSupply), oauthToken: this.options.oauth && this.options.apiToken },
 			req = rest[object == 'authorizations' ? 'post' : 'get'](apiUrl(object, this.options, false), dataObject);
 
@@ -84,7 +84,7 @@
 	// GET /items/find
 	RestHandlers.prototype.findItems = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { query: qs.stringify(paramsToSupply), oauthToken: this.options.oauth && this.options.apiToken },
 			req = rest.get(apiUrl(object + '/find', this.options, false), dataObject);
 
@@ -98,7 +98,7 @@
 	// GET /items/timeline
 	RestHandlers.prototype.timelineItems = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { query: qs.stringify(paramsToSupply), oauthToken: this.options.oauth && this.options.apiToken },
 			req = rest.get(apiUrl(object + '/timeline', this.options, false), dataObject);
 
@@ -112,7 +112,7 @@
 	// GET /searchResults/field
 	RestHandlers.prototype.searchFields = function(object, params, callback) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			dataObject = { query: qs.stringify(paramsToSupply), oauthToken: this.options.oauth && this.options.apiToken },
 			req = rest.get(apiUrl(object + '/field', this.options, false), dataObject);
 
@@ -126,7 +126,7 @@
 	// GET /items/5
 	RestHandlers.prototype.getItem = function(object, id, callback, params) {
 		var self = this,
-			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken ? { api_token: this.options.apiToken } : {}),
+			paramsToSupply = _.extend({}, _.isObject(params) ? params : {}, this.options.apiToken && !this.options.oauth ? { api_token: this.options.apiToken } : {}),
 			req = rest.get(apiUrl(object + '/' + id, this.options, false), { json: true, query: qs.stringify(paramsToSupply), oauthToken: this.options.oauth && this.options.apiToken });
 
 		req.on('complete', function(data, res) {


### PR DESCRIPTION
Pipedrive made changes and removed the proxy servers for oauth access. Us sending the access token as part of the query string broke things and stop the sync from working.
This PR updates the baseUri and removes the query string when using oauth.